### PR TITLE
Add posibility to override default naming strategy and to disable generating down migration scripts

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -78,7 +78,7 @@ func (mg *Migrator) Run(db *gorm.DB, command string, migrationname ...string) er
 			return nil
 		}
 
-		createCmd(mg.migrationPath, startTime.Unix(), migrationname[0], sqlUp, sqlDown)
+		mg.createCmd(startTime, migrationname[0], sqlUp, sqlDown)
 	}
 
 	if err != nil {
@@ -93,11 +93,11 @@ func (mg *Migrator) Run(db *gorm.DB, command string, migrationname ...string) er
 	return nil
 }
 
-func createCmd(migrationPath string, timestamp int64, name string, sqlUp string, sqlDown string) {
-	base := fmt.Sprintf("%v%v_%v.", migrationPath, timestamp, name)
-	_ = os.MkdirAll(migrationPath, os.ModePerm)
-	createFile(base+"up.sql", sqlUp)
-	createFile(base+"down.sql", sqlDown)
+func (mg *Migrator) createCmd(timestamp time.Time, name string, sqlUp string, sqlDown string) {
+	_ = os.MkdirAll(mg.migrationPath, os.ModePerm)
+	upName, downName := mg.NamingStrategy(mg.migrationPath, name, timestamp)
+	createFile(upName, sqlUp)
+	createFile(downName, sqlDown)
 }
 
 func createFile(fname string, content string) {

--- a/migration.go
+++ b/migration.go
@@ -97,7 +97,10 @@ func (mg *Migrator) createCmd(timestamp time.Time, name string, sqlUp string, sq
 	_ = os.MkdirAll(mg.migrationPath, os.ModePerm)
 	upName, downName := mg.NamingStrategy(mg.migrationPath, name, timestamp)
 	createFile(upName, sqlUp)
-	createFile(downName, sqlDown)
+
+	if mg.DownMigrationsEnabled {
+		createFile(downName, sqlDown)
+	}
 }
 
 func createFile(fname string, content string) {

--- a/migrator.go
+++ b/migrator.go
@@ -41,6 +41,7 @@ type Config struct {
 	CreateIndexAfterCreateTable bool
 	DB                          *gorm.DB
 	NamingStrategy              namingStrategy
+	DownMigrationsEnabled       bool
 	gorm.Dialector
 }
 
@@ -59,6 +60,7 @@ func New(db *gorm.DB, migrationFolder ...string) *Migrator {
 			CreateIndexAfterCreateTable: true,
 			DB:                          db,
 			NamingStrategy:              defaultNamingStrategy,
+			DownMigrationsEnabled:       true,
 		},
 		Models:        make([]interface{}, 0),
 		migrationPath: migrationPath,

--- a/migrator.go
+++ b/migrator.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	regRealDataType = regexp.MustCompile(`[^\d](\d+)[^\d]?`)
-	regFullDataType = regexp.MustCompile(`[^\d]*(\d+)[^\d]?`)
+	regRealDataType         = regexp.MustCompile(`[^\d](\d+)[^\d]?`)
+	regFullDataType         = regexp.MustCompile(`[^\d]*(\d+)[^\d]?`)
 	defaultMigrationsFolder = "migrations/sql"
 )
 


### PR DESCRIPTION
Hello there,
ive created this mr, because I want to have different timestamp format and also i dont want down migrations. As i need only up migrations, i dont need and thus want the up suffix either.

This mr adds possibility to override file naming strategy and disable generating down migration scripts.
```go
func main() {
       ...
	m := migrator.New(db, "migrations/")
	m.DownMigrationsEnabled = false
	m.NamingStrategy = func(migrationPath, name string, t time.Time) (string, string) {
          ...
           return upFileName, downFileName
        }
	...
}
```